### PR TITLE
ip checksum fix for odd data lengths

### DIFF
--- a/modules/PPE/module/src/ppe_util.c
+++ b/modules/PPE/module/src/ppe_util.c
@@ -41,7 +41,8 @@ sum16__(uint8_t* data, int len)
 
     if(len) {
         uint16_t b = data[olen-1];
-        if(*sdata != b) {
+        uint8_t* bdata = (uint8_t*)sdata;
+        if(*bdata != b) {
             sum += b<<8;
         }
         else {


### PR DESCRIPTION
Reviewer: @jnealtowns
cc: @rlane

Fix to address the invalid read during ip/icmp checksum calculation in case of odd data lengths.

Seen while running ivs with valgrind against icmpa.IcmpEchoRequest:

==852== Invalid read of size 2
==852==    at 0x5B338F: sum16__ (ppe_util.c:44)
==852==    by 0x5B33C9: ip_checksum__ (ppe_util.c:71)
==852==    by 0x5B3682: ppe_icmp_header_checksum_update (ppe_util.c:207)
==852==    by 0x5B27F1: ppe_packet_update (ppe_packet.c:71)
==852==    by 0x5B3865: ppe_build_icmp_packet (ppe_util.c:258)
==852==    by 0x5AD7E9: icmpa_build_pdu (icmpa.c:152)
==852==    by 0x5ADD2A: icmpa_reply (icmpa.c:260)
==852==    by 0x5ACEB3: icmpa_packet_in_handler (icmpa_handlers.c:146)
==852==    by 0x41F1F2: ind_core_packet_in_notify (listener.c:65)
==852==    by 0x4150E0: indigo_core_packet_in (ofstatemanager.c:114)
==852==    by 0x41FFA5: ind_fwd_pkt_in (fwd.c:581)
==852==    by 0x428603: ind_ovs_bh_run (bh.c:158)
==852==  Address 0x7f5dc28 is 72 bytes inside a block of size 73 alloc'd
==852==    at 0x402C877: malloc (vg_replace_malloc.c:291)
==852==    by 0x5ADC67: icmpa_reply (icmpa.c:250)
==852==    by 0x5ACEB3: icmpa_packet_in_handler (icmpa_handlers.c:146)
==852==    by 0x41F1F2: ind_core_packet_in_notify (listener.c:65)
==852==    by 0x4150E0: indigo_core_packet_in (ofstatemanager.c:114)
==852==    by 0x41FFA5: ind_fwd_pkt_in (fwd.c:581)
==852==    by 0x428603: ind_ovs_bh_run (bh.c:158)
==852==    by 0x40D35E: ind_soc_select_and_run (socketmanager.c:662)
==852==    by 0x40C0E2: aim_main (main.c:592)
==852==    by 0x403B81: main (aim_modules_init.c:204)
