### PR TITLE
Allow NULL to specify no formatting for pop-scope.

### DIFF
--- a/modules/IOF/module/src/iof.c
+++ b/modules/IOF/module/src/iof.c
@@ -96,8 +96,10 @@ int
 iof_pop(iof_t* iof)
 {
     --iof->level;
-    iof_indent(iof);
-    iof_uprintf(iof, "%s\n", iof->pop_string);
+    if(iof->pop_string) {
+        iof_indent(iof);
+        iof_uprintf(iof, "%s\n", iof->pop_string);
+    }
     return 0;
 }
 


### PR DESCRIPTION
Reviewer: trivial
