### PR TITLE
Allow hexadecimal integer formats. 

### DIFF
--- a/modules/cjson_util/module/auto/cjson_util.yml
+++ b/modules/cjson_util/module/auto/cjson_util.yml
@@ -1,21 +1,21 @@
 ############################################################
 # <bsn.cl fy=2014 v=epl>
-# 
-#           Copyright 2014 Big Switch Networks, Inc.          
-# 
+#
+#           Copyright 2014 Big Switch Networks, Inc.
+#
 # Licensed under the Eclipse Public License, Version 1.0 (the
 # "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
-# 
+#
 #        http://www.eclipse.org/legal/epl-v10.html
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the License for the specific
 # language governing permissions and limitations under the
 # License.
-# 
+#
 # </bsn.cl>
 ############################################################
 #
@@ -56,11 +56,5 @@ definitions:
   portingmacro:
     CJSON_UTIL:
       macros:
-        - malloc
-        - free
-        - memset
-        - memcpy
-        - strncpy
-        - vsnprintf
-        - snprintf
-        - strlen
+        - sscanf
+

--- a/modules/cjson_util/module/inc/cjson_util/cjson_util_porting.h
+++ b/modules/cjson_util/module/inc/cjson_util/cjson_util_porting.h
@@ -39,83 +39,13 @@
 #include <memory.h>
 #endif
 
-#ifndef CJSON_UTIL_MALLOC
-    #if defined(GLOBAL_MALLOC)
-        #define CJSON_UTIL_MALLOC GLOBAL_MALLOC
+#ifndef CJSON_UTIL_SSCANF
+    #if defined(GLOBAL_SSCANF)
+        #define CJSON_UTIL_SSCANF GLOBAL_SSCANF
     #elif CJSON_UTIL_CONFIG_PORTING_STDLIB == 1
-        #define CJSON_UTIL_MALLOC malloc
+        #define CJSON_UTIL_SSCANF sscanf
     #else
-        #error The macro CJSON_UTIL_MALLOC is required but cannot be defined.
-    #endif
-#endif
-
-#ifndef CJSON_UTIL_FREE
-    #if defined(GLOBAL_FREE)
-        #define CJSON_UTIL_FREE GLOBAL_FREE
-    #elif CJSON_UTIL_CONFIG_PORTING_STDLIB == 1
-        #define CJSON_UTIL_FREE free
-    #else
-        #error The macro CJSON_UTIL_FREE is required but cannot be defined.
-    #endif
-#endif
-
-#ifndef CJSON_UTIL_MEMSET
-    #if defined(GLOBAL_MEMSET)
-        #define CJSON_UTIL_MEMSET GLOBAL_MEMSET
-    #elif CJSON_UTIL_CONFIG_PORTING_STDLIB == 1
-        #define CJSON_UTIL_MEMSET memset
-    #else
-        #error The macro CJSON_UTIL_MEMSET is required but cannot be defined.
-    #endif
-#endif
-
-#ifndef CJSON_UTIL_MEMCPY
-    #if defined(GLOBAL_MEMCPY)
-        #define CJSON_UTIL_MEMCPY GLOBAL_MEMCPY
-    #elif CJSON_UTIL_CONFIG_PORTING_STDLIB == 1
-        #define CJSON_UTIL_MEMCPY memcpy
-    #else
-        #error The macro CJSON_UTIL_MEMCPY is required but cannot be defined.
-    #endif
-#endif
-
-#ifndef CJSON_UTIL_STRNCPY
-    #if defined(GLOBAL_STRNCPY)
-        #define CJSON_UTIL_STRNCPY GLOBAL_STRNCPY
-    #elif CJSON_UTIL_CONFIG_PORTING_STDLIB == 1
-        #define CJSON_UTIL_STRNCPY strncpy
-    #else
-        #error The macro CJSON_UTIL_STRNCPY is required but cannot be defined.
-    #endif
-#endif
-
-#ifndef CJSON_UTIL_VSNPRINTF
-    #if defined(GLOBAL_VSNPRINTF)
-        #define CJSON_UTIL_VSNPRINTF GLOBAL_VSNPRINTF
-    #elif CJSON_UTIL_CONFIG_PORTING_STDLIB == 1
-        #define CJSON_UTIL_VSNPRINTF vsnprintf
-    #else
-        #error The macro CJSON_UTIL_VSNPRINTF is required but cannot be defined.
-    #endif
-#endif
-
-#ifndef CJSON_UTIL_SNPRINTF
-    #if defined(GLOBAL_SNPRINTF)
-        #define CJSON_UTIL_SNPRINTF GLOBAL_SNPRINTF
-    #elif CJSON_UTIL_CONFIG_PORTING_STDLIB == 1
-        #define CJSON_UTIL_SNPRINTF snprintf
-    #else
-        #error The macro CJSON_UTIL_SNPRINTF is required but cannot be defined.
-    #endif
-#endif
-
-#ifndef CJSON_UTIL_STRLEN
-    #if defined(GLOBAL_STRLEN)
-        #define CJSON_UTIL_STRLEN GLOBAL_STRLEN
-    #elif CJSON_UTIL_CONFIG_PORTING_STDLIB == 1
-        #define CJSON_UTIL_STRLEN strlen
-    #else
-        #error The macro CJSON_UTIL_STRLEN is required but cannot be defined.
+        #error The macro CJSON_UTIL_SSCANF is required but cannot be defined.
     #endif
 #endif
 

--- a/modules/cjson_util/utest/main.c
+++ b/modules/cjson_util/utest/main.c
@@ -57,7 +57,9 @@ int aim_main(int argc, char* argv[])
         "      \"i2\": 2, "
         "      \"more\": { "
         "        \"i3\": 3, "
-        "        \"i4\": 4 "
+        "        \"i4\": 4, "
+        "        \"hex\": \"0xDEADf00d\","
+        "        \"hexbad\": \"DEADBEEF\""
         "        }"
         "     }, "
         " \"doubles\": {"
@@ -130,7 +132,12 @@ int aim_main(int argc, char* argv[])
     AIM_ASSERT(dv >= 3.141 && dv <= 3.15);
     TRY(cjson_util_lookup_string(root, &sv, "data.strings.alpha.bravo.charlie.delta"));
     AIM_ASSERT(!strcmp(sv, "foxtrot"));
-
+    TRY(cjson_util_lookup_string(root, &sv, "data.int.more.hex"));
+    AIM_ASSERT(!strcmp(sv, "0xDEADf00d"));
+    TRY(cjson_util_lookup_int(root, &iv, "data.int.more.hex"));
+    AIM_ASSERT(iv == 0xdeadf00d);
+    TRY(cjson_util_lookup_string(root, &sv, "data.int.more.hexbad"));
+    AIM_ASSERT(cjson_util_lookup_int(root, &iv, "data.int.more.hexbad") == AIM_ERROR_PARAM);
     cJSON_Delete(root);
     return 0;
 }


### PR DESCRIPTION
Reviewer: trivial

Allow a hexadecimal value to be specified as a string field and retrieved as an integer.
Values specified in this way must start with 0x or 0X.

JSON does not support hexadecimal number formats, which becomes annoying and tedious to workaround. 
