### PR TITLE
debug_counter: add DEBUG_COUNTER convenience macro

### DIFF
--- a/modules/debug_counter/module/inc/debug_counter/debug_counter.h
+++ b/modules/debug_counter/module/inc/debug_counter/debug_counter.h
@@ -45,6 +45,13 @@
 #define DEBUG_COUNTER_NAME_SIZE 64
 #define DEBUG_COUNTER_DESCRIPTION_SIZE 256
 
+#define DEBUG_COUNTER(ident, name, description) \
+    static debug_counter_t ident; \
+    static void __attribute__((constructor)) ident ## _constructor(void) \
+    { \
+        debug_counter_register(&ident, name, description); \
+    }
+
 /**
  * Debug counter
  *

--- a/modules/debug_counter/utest/main.c
+++ b/modules/debug_counter/utest/main.c
@@ -19,8 +19,36 @@
 
 #include <debug_counter/debug_counter.h>
 
+DEBUG_COUNTER(static_debug_counter, "static counter", "Static debug counter");
+
+static bool
+is_counter_registered(const debug_counter_t *target)
+{
+    list_head_t *counters;
+    list_links_t *cur, *next;
+    counters = debug_counter_list();
+    LIST_FOREACH_SAFE(counters, cur, next) {
+        debug_counter_t *counter = container_of(cur, links, debug_counter_t);
+        if (target == counter) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 int aim_main(int argc, char* argv[])
 {
+    /* Test static counter */
+    {
+        AIM_ASSERT(is_counter_registered(&static_debug_counter));
+        AIM_ASSERT(debug_counter_get(&static_debug_counter) == 0);
+        debug_counter_inc(&static_debug_counter);
+        AIM_ASSERT(debug_counter_get(&static_debug_counter) == 1);
+        debug_counter_unregister(&static_debug_counter);
+        AIM_ASSERT(!is_counter_registered(&static_debug_counter));
+    }
+
     /* Unregister existing counters */
     {
         list_head_t *counters;

--- a/targets/utests/ELS/Makefile
+++ b/targets/utests/ELS/Makefile
@@ -11,10 +11,11 @@ include ../../../init.mk
 
 MODULE := ELS_utest
 TEST_MODULE :=  ELS
-DEPENDMODULES := AIM
+DEPENDMODULES := AIM OS
 
 GLOBAL_LINK_LIBS += -lpthread -ledit
 PEDANTIC := 1
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_POSIX=1
 
 include $(BUILDER)/build-unit-test.mk
 


### PR DESCRIPTION
Reviewer: @jnealtowns

This macro declares a debug_counter_t global and registers it. It's more 
ergonomic than declaring the global in one place and registering it in
another. Also, many files don't have a natural place to call
debug_counter_register.