### PR TITLE
ucli: fixed minor segfault with help function

### DIFF
--- a/modules/uCli/module/src/ucli_module.c
+++ b/modules/uCli/module/src/ucli_module.c
@@ -211,10 +211,13 @@ ucli_module_complete(ucli_module_t* mod, const char** tokens)
          */
         char* help;
         possibilities = NULL;
-        count = UCLI_STRLEN(cp->command)+UCLI_STRLEN(cp->help.args)+2;
+        count = UCLI_STRLEN(cp->command)+2;
+        if (cp->help.args)
+            count += UCLI_STRLEN(cp->help.args);
 
         help = aim_zmalloc(count);
-        aim_snprintf(help, count, "%s %s", cp->command, cp->help.args);
+        aim_snprintf(help, count, "%s %s", cp->command, cp->help.args?
+                                                        cp->help.args:"");
         possibilities = biglist_append(possibilities, help);
         ucomp = aim_zmalloc(sizeof(*ucomp));
         ucomp->possibilities.list = possibilities;


### PR DESCRIPTION
If command's help.args was NULL (e.g., with BRCM's debug), <tab,tab>
would cause an instant segfault.

Reviewer: @jnealtowns @rlane 