### PR TITLE
Don't fail on duplicate next_hop

### DIFF
--- a/modules/orc/module/src/netlink_mon.c
+++ b/modules/orc/module/src/netlink_mon.c
@@ -449,9 +449,8 @@ static int handle_v4_route(
                     entry.dst_ip,
                     netmask)) != 0)
             {
-                orc_warn("pending_next_hop_add_gateway() failed: %d\n",
+                orc_debug("pending_next_hop_add_gateway() failed: %d\n",
                         err);
-                return -1;
             }
             call_add_l3_v4_route(options,
                     entry.dst_ip,
@@ -464,9 +463,8 @@ static int handle_v4_route(
                     entry.dst_ip,
                     netmask)) != 0)
             {
-                orc_warn("pending_next_hop_add_direct() failed: %d\n",
+                orc_debug("pending_next_hop_add_direct() failed: %d\n",
                         err);
-                return -1;
             }
         }
     }
@@ -493,9 +491,8 @@ static int handle_v4_route(
                     entry.dst_ip,
                     netmask)) != 0)
             {
-                orc_warn("pending_next_hop_del_gateway() failed: %d\n",
+                orc_debug("pending_next_hop_del_gateway() failed: %d\n",
                         err);
-                return -1;
             }
         } else {    /* direct route */
             if ((err = pending_next_hop_del_direct(
@@ -503,9 +500,8 @@ static int handle_v4_route(
                     entry.dst_ip,
                     netmask)) != 0)
             {
-                orc_warn("pending_next_hop_del_gateway() failed: %d\n",
+                orc_debug("pending_next_hop_del_gateway() failed: %d\n",
                         err);
-                return -1;
             }
         }
     }


### PR DESCRIPTION
netlink_mon.c deliberately does duplicate next_hop adds and removes, so it shouldn't fail when it gets a "duplicate next hop" error

this patch fixes this - enabling multiple routes per next_hop

this has been tested on ONL on AS5710-54X with 8192 routes