### PR TITLE
slot_allocator: fix iteration after an all-ones bitmap word

### DIFF
--- a/modules/slot_allocator/module/src/slot_allocator.c
+++ b/modules/slot_allocator/module/src/slot_allocator.c
@@ -157,7 +157,7 @@ slot_allocator_iter_next(struct slot_allocator_iter *iter)
     }
 
     /* Advance to next bitmap word */
-    iter->slot += AIM_BITMAP_BITS_PER_WORD;
+    iter->slot += AIM_BITMAP_BITS_PER_WORD-1;
     iter->slot &= ~(AIM_BITMAP_BITS_PER_WORD-1);
 
     /* Find the next nonzero bitmap word */


### PR DESCRIPTION
Reviewer: @harshsin

When a bitmap word is full then the fastpath is taken 32 times, each time 
adding 1 to the slot number. The previous code then added 32 to the slot
number and ANDed it with 31 to get to the next bitmap word. However, since the 
fastpath already added 32 to the slot number this skipped a bitmap word.

The fix is to add 31 instead of 32. This is reliable because we maintain the 
invariant that the fastpath will be taken at least once.