### PR TITLE
True Relative Semaphore Timeout Support.

### DIFF
--- a/modules/OS/module/inc/OS/os_sem.h
+++ b/modules/OS/module/inc/OS/os_sem.h
@@ -35,8 +35,21 @@ typedef struct os_sem_s* os_sem_t;
 /**
  * @brief Create a semaphore.
  * @param count Initial count.
+ * @param ... Optional uint32_t creation flags.
  */
-os_sem_t os_sem_create(int count);
+os_sem_t os_sem_create(int count, ...);
+
+/**
+ * Specify this flag in os_sem_create() if you plan to
+ * used timeouts with your semaphore. This option
+ * will implement true relative timeouts that are immune
+ * to clock adjustments (but will not perform as well).
+ */
+#define OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS 0x1
+
+
+
+
 
 /**
  * @brief Destroy a semaphore.

--- a/modules/OS/module/inc/OS/os_sem.h
+++ b/modules/OS/module/inc/OS/os_sem.h
@@ -35,20 +35,23 @@ typedef struct os_sem_s* os_sem_t;
 /**
  * @brief Create a semaphore.
  * @param count Initial count.
- * @param ... Optional uint32_t creation flags.
  */
-os_sem_t os_sem_create(int count, ...);
+os_sem_t os_sem_create(int count);
 
 /**
- * Specify this flag in os_sem_create() if you plan to
+ * Specify this flag in os_sem_create_flags() if you plan to
  * used timeouts with your semaphore. This option
  * will implement true relative timeouts that are immune
  * to clock adjustments (but will not perform as well).
  */
 #define OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS 0x1
 
-
-
+/**
+ * @brief Create a semaphore.
+ * @param count Initial count.
+ * @param ... Optional uint32_t creation flags.
+ */
+os_sem_t os_sem_create_flags(int count, uint32_t flags);
 
 
 /**

--- a/modules/OS/module/src/os_sem_none.c
+++ b/modules/OS/module/src/os_sem_none.c
@@ -27,7 +27,7 @@ struct os_sem_s {
 };
 
 os_sem_t
-os_sem_create(int count)
+os_sem_create(int count, ...)
 {
     os_sem_t s = aim_zmalloc(sizeof(*s));
     s->count = count;

--- a/modules/OS/module/src/os_sem_none.c
+++ b/modules/OS/module/src/os_sem_none.c
@@ -27,11 +27,17 @@ struct os_sem_s {
 };
 
 os_sem_t
-os_sem_create(int count, ...)
+os_sem_create_flags(int count, uint32_t flags)
 {
     os_sem_t s = aim_zmalloc(sizeof(*s));
     s->count = count;
     return s;
+}
+
+os_sem_t
+os_sem_create(int count)
+{
+    return os_sem_create_flags(count, 0);
 }
 
 void

--- a/modules/OS/module/src/os_sem_posix.c
+++ b/modules/OS/module/src/os_sem_posix.c
@@ -141,7 +141,7 @@ timespec_init_timeout__(struct timespec* ts, uint64_t us)
 static int
 os_sem_take_timeout_efd__(os_sem_t sem, uint64_t usecs)
 {
-    AIM_TRUE_OR_DIE(USES_EFD(sem));
+    AIM_TRUE_OR_DIE(USES_EFD(sem), "timeout_efd__ called when efd is not valid.");
 
     /** poll() with timeout (in ms) */
     struct pollfd fds;
@@ -213,7 +213,7 @@ os_sem_take_timeout_efd__(os_sem_t sem, uint64_t usecs)
 static int
 os_sem_take_timeout_sem__(os_sem_t sem, uint64_t usecs)
 {
-    AIM_TRUE_OR_DIE(!USES_EFD(sem));
+    AIM_TRUE_OR_DIE(!USES_EFD(sem), "timout_sem__ called while EFD in use.");
 
     if(usecs == 0) {
         /** Normal wait */

--- a/modules/OS/module/src/os_sem_posix.c
+++ b/modules/OS/module/src/os_sem_posix.c
@@ -151,7 +151,6 @@ os_sem_take_timeout_efd__(os_sem_t sem, uint64_t usecs)
     fds.revents = 0;
 
     uint64_t t_start = os_time_monotonic();
-    uint64_t t_poll_started = t_start;
     int timeout_ms;
 
     if(usecs == 0) {
@@ -198,8 +197,7 @@ os_sem_take_timeout_efd__(os_sem_t sem, uint64_t usecs)
                 }
                 else {
                     /* Remaining time to wait. */
-                    timeout_ms -= (now - t_poll_started) / 1000;
-                    t_poll_started = now;
+                    timeout_ms = (usecs - (now - t_start) + 999)/1000;
                 }
             }
             continue;

--- a/modules/OS/module/src/os_sem_windows.c
+++ b/modules/OS/module/src/os_sem_windows.c
@@ -27,7 +27,7 @@ struct os_sem_s {
 };
 
 os_sem_t
-os_sem_create(int count)
+os_sem_create(int count, ...)
 {
     os_sem_t s = aim_zmalloc(sizeof(*s));
     s->count = count;

--- a/modules/OS/module/src/os_sem_windows.c
+++ b/modules/OS/module/src/os_sem_windows.c
@@ -27,11 +27,17 @@ struct os_sem_s {
 };
 
 os_sem_t
-os_sem_create(int count, ...)
+os_sem_create_flags(int count, uint32_t flags)
 {
     os_sem_t s = aim_zmalloc(sizeof(*s));
     s->count = count;
     return s;
+}
+
+os_sem_t
+os_sem_create(int count)
+{
+    return os_sem_create_flags(count, 0);
 }
 
 void

--- a/modules/OS/utest/main.c
+++ b/modules/OS/utest/main.c
@@ -26,7 +26,7 @@
 
 int main(int argc, char* argv[])
 {
-    printf("OS Utest Is Empty\n");
+
     os_config_show(&aim_pvs_stdout);
 
     printf("os_sem_create=%p\n", os_sem_create);
@@ -113,7 +113,7 @@ int main(int argc, char* argv[])
         /* From semtest.c */
         extern void sem_test_multiple(uint32_t flags, int givers, int takers);
         printf("Semaphore timeout test (normal)...\n");
-        sem_test_multiple(OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS, 512, 1024);
+        sem_test_multiple(0, 512, 1024);
         printf("Semaphore timeout test (relative)...\n");
         sem_test_multiple(OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS, 512, 1024);
     }

--- a/modules/OS/utest/main.c
+++ b/modules/OS/utest/main.c
@@ -38,7 +38,7 @@ int main(int argc, char* argv[])
 
     {
         os_sem_t sem = os_sem_create(1);
-        printf("sem=%p\n", sem);
+        printf("sem(regular)=%p\n", sem);
         printf("take\n");
         os_sem_take(sem);
         printf("give\n");
@@ -47,9 +47,22 @@ int main(int argc, char* argv[])
         os_sem_take(sem);
         os_sem_destroy(sem);
     }
+
+    {
+        os_sem_t sem = os_sem_create(1, OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS);
+        printf("sem(relative timeout)=%p\n", sem);
+        printf("take\n");
+        os_sem_take(sem);
+        printf("give\n");
+        os_sem_give(sem);
+        printf("take\n");
+        os_sem_take(sem);
+        os_sem_destroy(sem);
+    }
+
     {
         int i;
-        printf("Should print every second...");
+        printf("Should print every second (sleep)...");
         for(i = 0; i <= 5; i++) {
             aim_printf(&aim_pvs_stdout, "%d ", i);
             if(i & 1) {
@@ -64,7 +77,7 @@ int main(int argc, char* argv[])
     {
         int i;
         os_sem_t s = os_sem_create(1);
-        printf("Should print every second...");
+        printf("Should print every second (sem)...");
         for(i = 0; i <= 5; i++) {
             aim_printf(&aim_pvs_stdout, "%d ", i);
             AIM_TRUE_OR_DIE(os_sem_take_timeout(s, 0) == 0);
@@ -73,8 +86,22 @@ int main(int argc, char* argv[])
             AIM_TRUE_OR_DIE(os_sem_take_timeout(s, 1000000) == 0);
             os_sem_give(s);
         }
+        printf("\n");
     }
-
+    {
+        int i;
+        os_sem_t s = os_sem_create(1, OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS);
+        printf("Should print every second (relative-timeout)...");
+        for(i = 0; i <= 5; i++) {
+            aim_printf(&aim_pvs_stdout, "%d ", i);
+            AIM_TRUE_OR_DIE(os_sem_take_timeout(s, 0) == 0);
+            AIM_TRUE_OR_DIE(os_sem_take_timeout(s, 1000000) == -1);
+            os_sem_give(s);
+            AIM_TRUE_OR_DIE(os_sem_take_timeout(s, 1000000) == 0);
+            os_sem_give(s);
+        }
+        printf("\n");
+    }
     {
         const char* name = "thready";
         char n[32];

--- a/modules/OS/utest/main.c
+++ b/modules/OS/utest/main.c
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
     }
 
     {
-        os_sem_t sem = os_sem_create(1, OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS);
+        os_sem_t sem = os_sem_create_flags(1, OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS);
         printf("sem(relative timeout)=%p\n", sem);
         printf("take\n");
         os_sem_take(sem);
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
     }
     {
         int i;
-        os_sem_t s = os_sem_create(1, OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS);
+        os_sem_t s = os_sem_create_flags(1, OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS);
         printf("Should print every second (relative-timeout)...");
         for(i = 0; i <= 5; i++) {
             aim_printf(&aim_pvs_stdout, "%d ", i);
@@ -109,6 +109,13 @@ int main(int argc, char* argv[])
         os_thread_name_get(n, sizeof(n));
         AIM_TRUE_OR_DIE(!strcmp(name, n));
     }
-
+    {
+        /* From semtest.c */
+        extern void sem_test_multiple(uint32_t flags, int givers, int takers);
+        printf("Semaphore timeout test (normal)...\n");
+        sem_test_multiple(OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS, 512, 1024);
+        printf("Semaphore timeout test (relative)...\n");
+        sem_test_multiple(OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS, 512, 1024);
+    }
     return 0;
 }

--- a/modules/OS/utest/semtest.c
+++ b/modules/OS/utest/semtest.c
@@ -1,0 +1,143 @@
+/****************************************************************
+ *
+ *        Copyright 2013, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ***************************************************************/
+
+#include <OS/os_config.h>
+#include <OS/os.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <pthread.h>
+
+typedef struct sem_test_s {
+    pthread_t thread;
+
+    char name[64];
+    os_sem_t take;
+    os_sem_t give;
+    uint64_t timeout;
+    int timeout_required;
+    int* acquired;
+
+} sem_test_t;
+
+static void*
+sem_test_thread__(void* p)
+{
+    int rv;
+    sem_test_t* t = (sem_test_t*)p;
+
+    uint64_t t0 = os_time_monotonic();
+    rv = os_sem_take_timeout(t->take, t->timeout);
+    uint64_t t1 = os_time_monotonic();
+
+    uint64_t duration = t1 - t0;
+    int64_t delta = t->timeout - duration;
+
+    printf("%s: rv=% d timeout: %.8" PRId64 " duration: %.8" PRId64 " delta: % .8" PRId64 "\n", t->name, rv, t->timeout, duration, delta);
+
+    if(rv == -1) {
+        if(delta > 0) {
+            AIM_DIE("%s: premature timeout.", t->name);
+        }
+        /* Arbitrary, within 30ms */
+        if(delta < -30000 && t->timeout) {
+            AIM_DIE("%s: timeout blown.", t->name);
+        }
+    }
+    else if(rv == 0) {
+        if(delta < 0 && t->timeout) {
+            AIM_DIE("%s: waited longer than timeout.", t->name);
+        }
+        if(t->timeout_required) {
+            AIM_DIE("%s: timeout was required.", t->name);
+        }
+        (*t->acquired)++;
+    }
+
+    if(t->give) {
+        os_sem_give(t->give);
+    }
+    return NULL;
+}
+
+void
+sem_test_multiple(uint32_t flags, int giving_threads, int taking_threads)
+{
+    int i;
+
+    int thread_count = giving_threads + taking_threads;
+    sem_test_t* tests = aim_zmalloc(sizeof(*tests)*thread_count);
+
+    os_sem_t take = os_sem_create_flags(0, flags);
+    os_sem_t give = os_sem_create_flags(0, flags);
+    int acquired = 0;
+    sem_test_t* t = tests;
+
+    /*
+     * These threads wait on a semaphore timeout
+     * that will always expire. Timeout in [10000,100000].
+     *
+     * When the first timeout expires they give a different sem.
+     */
+    for(i = 0; i < giving_threads; i++, t++) {
+        t->take = take;
+        t->give = give;
+        sprintf(t->name, "(1:%.4d)", i);
+        t->timeout = ( (random() % 10) + 1 ) * 100000;
+        t->timeout_required = 1;
+        t->acquired = &acquired;
+        pthread_create(&t->thread, NULL, sem_test_thread__, t);
+    }
+
+    /*
+     * These threads wait on the semaphore given at the end
+     * of the waiting period for the first set of threads.
+     *
+     * Some will timeout, some will acquire.
+     *
+     * Their timeouts are all in [2000000, 3000000].
+     */
+    for(i = 0; i < taking_threads; i++, t++) {
+        t->take = give;
+        t->give = NULL;
+        sprintf(t->name, "(2:%.4d)", i);
+        t->timeout = 2000000 + (( (random() % 10) + 1 ) * 100000);
+        t->give = 0;
+        t->timeout_required = 0;
+        t->acquired = &acquired;
+        pthread_create(&t->thread, NULL, sem_test_thread__, t);
+    }
+
+    for(i = 0; i < thread_count; i++) {
+        void* rv;
+        pthread_join(tests[i].thread, &rv);
+    }
+
+    /*
+     * The acquisition count should always be equal to the number
+     * of giving threads when (giving_threads <= taking_threads).
+     */
+    printf("Acquisition count: %d\n", acquired);
+    AIM_TRUE_OR_DIE(acquired == giving_threads);
+
+    aim_free(give);
+    aim_free(take);
+    aim_free(tests);
+}

--- a/targets/utests/OS/Makefile
+++ b/targets/utests/OS/Makefile
@@ -1,27 +1,27 @@
 #################################################################
-# 
-#        Copyright 2013, Big Switch Networks, Inc. 
-# 
+#
+#        Copyright 2013, Big Switch Networks, Inc.
+#
 # Licensed under the Eclipse Public License, Version 1.0 (the
 # "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
-# 
+#
 #        http://www.eclipse.org/legal/epl-v10.html
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the License for the specific
 # language governing permissions and limitations under the
 # License.
-# 
+#
 #################################################################
 include ../../../init.mk
 
 MODULE := OS_utest
 TEST_MODULE :=  OS
 DEPENDMODULES := AIM
-OS_CFLAGS += -DOS_CONFIG_INCLUDE_POSIX=1
+GLOBAL_CFLAGS += -DOS_CONFIG_INCLUDE_POSIX=1
 LDFLAGS += -lpthread -lrt
 
 include $(BUILDER)/build-unit-test.mk


### PR DESCRIPTION
Reviewer: @rlane 

The posix semaphore specification (inexplicably) requires timeout values relative to the REALTIME clock.
Changes to the value of the REALTIME while waiting on the semaphore (due to manual or NTP updates)
will make the timeout expire prematurely if the change is in the future or wildly overdue if the change is in the past.

The os_sem_create() function has been augmented with a backwards-compatible, optional 'flags' argument.
The only flag current supported is OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS.

When the OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS flags is specified at creation time, semaphores
will be implemented internally using the eventfd interface (instead of the posix interface).
Timeouts are then implemented with poll(), whose timeout value is relative and immune to REALTIME clock changes.

All clients which rely on os_sem_take_timeout() should use the OS_SEM_CREATE_F_TRUE_RELATIVE_TIMEOUTS flag.
Clients which do not use os_sem_take_timeout() on the semaphore need not specify it (and probably shouldn't due to performance differences).