### PR TITLE
SWL-2161 Use first 63 bytes as the default key

### DIFF
--- a/modules/pimu/module/src/pimu.c
+++ b/modules/pimu/module/src/pimu.c
@@ -171,8 +171,12 @@ pimu_flow_action__(pimu_t* pimu, int pid,
             return PIMU_ACTION_ERROR;
         }
         data = key;
-    } else if(size < PIMU_CONFIG_PACKET_KEY_SIZE) {
-        PIMU_MEMCPY(key, data, size);
+    } else {
+        if(size < PIMU_CONFIG_PACKET_KEY_SIZE) {
+            PIMU_MEMCPY(key, data, size);
+        } else {
+            PIMU_MEMCPY(key, data, PIMU_CONFIG_PACKET_KEY_SIZE - 1);
+        }
         data = key;
     }
     pe = (pimu_entry_t*)nwac_search(pimu->nwac, data, now);


### PR DESCRIPTION
Reviewer: @jnealtowns @wilmo119 

Since all packets are at least 64 bytes, the original else block was not executed.