### PR TITLE
ORC: only add a next_hop if it had a MAC address

### DIFF
--- a/modules/orc/module/src/netlink_mon.c
+++ b/modules/orc/module/src/netlink_mon.c
@@ -602,8 +602,8 @@ static int parse_v4_neighbor(
                 orc_warn("Skipping unhandled ipv4 neighbor attr: %d\n", attr->rta_type);
         };
     }
-
-    return found_l3_addr;
+    /** we found a complete/valid entry iff it has a mac and an IP **/
+    return (found_l3_addr && neigh->mac_valid);
 }
 
 


### PR DESCRIPTION
Adjust the definition of a valid/complete neighbor
to avoid calling the driver with mac=00:00:00:00:00:00

Thanks Ryan for the help in finding

Reviewer: @rizard 