### PR TITLE
bigring: Use aim_free for aim_malloced memory.

### DIFF
--- a/modules/BigData/BigRing/module/inc/BigRing/bigring.h
+++ b/modules/BigData/BigRing/module/inc/BigRing/bigring.h
@@ -42,10 +42,10 @@ typedef struct bigring_s bigring_t;
 typedef void (*bigring_free_entry_f)(void* entry);
 
 /**
- * @brief Builtin deallocator -- calls AIM_FREE() on the entry.
+ * @brief Builtin deallocator -- calls aim_free() on the entry.
  * @param entry The entry
  * @note Pass this as the deallocator if your objects should
- * just be freed using AIM_FREE().
+ * just be freed using aim_free().
  */
 void bigring_aim_free_entry(void* entry);
 
@@ -55,7 +55,7 @@ void bigring_aim_free_entry(void* entry);
  * @param free_entry The entry deallocator.
  * @note If free_entry is NULL, the entries will not be freed.
  * @note pass bigring_aim_free_entry() if you want normal deallocation.
- * using AIM_FREE()
+ * using aim_free()
  */
 bigring_t* bigring_create(int size, bigring_free_entry_f free_entry);
 

--- a/modules/BigData/BigRing/module/src/bigring.c
+++ b/modules/BigData/BigRing/module/src/bigring.c
@@ -113,8 +113,8 @@ bigring_destroy(bigring_t* br)
     os_sem_destroy(br->lock);
 #endif
 
-    AIM_FREE(br->ring);
-    AIM_FREE(br);
+    aim_free(br->ring);
+    aim_free(br);
 }
 
 void
@@ -228,7 +228,7 @@ bigring_iter_next(bigring_t* br, int* iter)
 void
 bigring_aim_free_entry(void* entry)
 {
-    AIM_FREE(entry);
+    aim_free(entry);
 }
 
 int


### PR DESCRIPTION
Reviewer: @jnealtowns 

When used with a memory tracker built on aim_malloc and aim_free, the aim_free changes will reduce the number of cases where memory is apparently leaked but really is not.