### PR TITLE
stopping snmp subagent

### DIFF
--- a/modules/snmp_subagent/module/src/snmp_subagent_thread.c
+++ b/modules/snmp_subagent/module/src/snmp_subagent_thread.c
@@ -117,9 +117,7 @@ check_and_process(int block, int evtfd)
         numfds = evtfd + 1;
     }
 
-    AIM_LOG_INFO("before select, evtfd %d", evtfd);
     count = select(numfds, &fdset, 0, 0, tvp);
-    AIM_LOG_INFO("after select");
 
     if (count > 0) {
         /* check evtfd, abort if necessary */
@@ -166,7 +164,6 @@ snmp_subagent_worker__(void* p)
     volatile snmp_subagent_thread_ctrl_t* ctrl = (volatile snmp_subagent_thread_ctrl_t*) p;
     char buffer[128];
 
-    AIM_LOG_INFO("snmp subagent thread starting (%s)", ctrl->name);
     aim_snprintf(buffer, sizeof(buffer), "snmp.subagent.%s", ctrl->name);
     os_thread_name_set(buffer);
 
@@ -194,13 +191,11 @@ snmp_subagent_worker__(void* p)
      * Agent process.
      */
     init_snmp(ctrl->name);
-    AIM_LOG_INFO("snmp subagent thread processing (%s)", ctrl->name);
     while(ctrl->run) {
         check_and_process(1, ctrl->eventfd);
     }
     snmp_shutdown(ctrl->name);
     SOCK_CLEANUP;
-    AIM_LOG_INFO("snmp subagent thread finished (%s)", ctrl->name);
 
     return (void*)ctrl;
 }

--- a/modules/snmp_subagent/module/src/snmp_subagent_thread.c
+++ b/modules/snmp_subagent/module/src/snmp_subagent_thread.c
@@ -28,6 +28,10 @@
 
 #include <pthread.h>
 #include <signal.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/eventfd.h>
+
 
 /** Thread control. */
 typedef struct snmp_subagent_thread_ctrl_s {
@@ -35,7 +39,7 @@ typedef struct snmp_subagent_thread_ctrl_s {
     const char* name;
     int failed;
     int debugging;
-
+    int eventfd;  /* eventfd for aborting check_and_process */
 } snmp_subagent_thread_ctrl_t;
 
 static pthread_t subagent_thread_handle__;
@@ -44,12 +48,114 @@ static volatile snmp_subagent_thread_ctrl_t ctrl__;
 
 
 /**
+ * Send notification to stop worker thread.
+ */
+static void
+notify_stop(void)
+{
+    uint64_t one = 1;
+    if (write(ctrl__.eventfd, &one, sizeof(one)) < 0) {
+        /* silence warn_unused_result */
+    }
+}
+
+
+/**
  * Signal handlers which terminal the worker thread.
  */
 static RETSIGTYPE
 sig_stop_handler__(int a) {
     ctrl__.run = 0;
+    notify_stop();
 }
+
+
+/**
+ * net-snmp main loop,
+ * modified from net-snmp-5.4.3/agent/snmp_agent.c:agent_check_and_process().
+ * fdset is extended with eventfd to signal that check_and_process loop should
+ * be aborted early.
+ */
+static int
+check_and_process(int block, int evtfd)
+{
+    int             numfds;
+    fd_set          fdset;
+    struct timeval  timeout = { LONG_MAX, 0 }, *tvp = &timeout;
+    int             count;
+    int             fakeblock = 0;
+
+    numfds = 0;
+    FD_ZERO(&fdset);
+    snmp_select_info(&numfds, &fdset, tvp, &fakeblock);
+    if (block != 0 && fakeblock != 0) {
+        /*
+         * There are no alarms registered, and the caller asked for blocking, so
+         * let select() block forever.
+         */
+
+        tvp = NULL;
+    } else if (block != 0 && fakeblock == 0) {
+        /*
+         * The caller asked for blocking, but there is an alarm due sooner than
+         * LONG_MAX seconds from now, so use the modified timeout returned by
+         * snmp_select_info as the timeout for select().
+         */
+
+    } else if (block == 0) {
+        /*
+         * The caller does not want us to block at all.
+         */
+
+        tvp->tv_sec = 0;
+        tvp->tv_usec = 0;
+    }
+
+    /* add evtfd to fdset, update numfds */
+    FD_SET(evtfd, &fdset);
+    if (evtfd + 1 > numfds) {
+        numfds = evtfd + 1;
+    }
+
+    AIM_LOG_INFO("before select, evtfd %d", evtfd);
+    count = select(numfds, &fdset, 0, 0, tvp);
+    AIM_LOG_INFO("after select");
+
+    if (count > 0) {
+        /* check evtfd, abort if necessary */
+        if (FD_ISSET(evtfd, &fdset)) {
+            return count;
+        }
+
+        /*
+         * packets found, process them
+         */
+        snmp_read(&fdset);
+    } else
+        switch (count) {
+        case 0:
+            snmp_timeout();
+            break;
+        case -1:
+            if (errno != EINTR) {
+                snmp_log_perror("select");
+            }
+            return -1;
+        default:
+            snmp_log(LOG_ERR, "select returned %d\n", count);
+            return -1;
+        }                       /* endif -- count>0 */
+
+    /*
+     * Run requested alarms.
+     */
+    run_alarms();
+
+    netsnmp_check_outstanding_agent_requests();
+
+    return count;
+}
+
 
 /**
  * This thread performs SNMP agentx dispatching.
@@ -90,11 +196,11 @@ snmp_subagent_worker__(void* p)
     init_snmp(ctrl->name);
     AIM_LOG_INFO("snmp subagent thread processing (%s)", ctrl->name);
     while(ctrl->run) {
-        agent_check_and_process(1);
+        check_and_process(1, ctrl->eventfd);
     }
     snmp_shutdown(ctrl->name);
     SOCK_CLEANUP;
-    AIM_LOG_INFO("snmp suubagent thread finished (%s)", ctrl->name);
+    AIM_LOG_INFO("snmp subagent thread finished (%s)", ctrl->name);
 
     return (void*)ctrl;
 }
@@ -115,6 +221,9 @@ snmp_subagent_start(const char* name, int join, int debugging)
     ctrl__.name = aim_strdup(name);
     ctrl__.failed = 0;
     ctrl__.debugging = debugging;
+    ctrl__.eventfd = eventfd(0, 0);
+
+    AIM_TRUE_OR_DIE(ctrl__.eventfd >= 0);
 
     if(pthread_create(&subagent_thread_handle__, NULL,
                       snmp_subagent_worker__, (void*)&ctrl__) < 0) {
@@ -137,6 +246,7 @@ snmp_subagent_stop(void)
         return -1;
     }
     ctrl__.run = 0;
+    notify_stop();
     pthread_join(subagent_thread_handle__, NULL);
     subagent_thread_running__ = 0;
     return 0;


### PR DESCRIPTION
Reviewer: @jnealtowns 

Clone net-snmp's agent_check_and_process and rename to check_and_process.
Modify check_and_process to select on an eventfd,
so that check_and_process can be terminated when the snmp subagent is stopped.