### PR TITLE
cjson_file_util: sub-second resolution for file modification time

### DIFF
--- a/modules/cjson_util/module/inc/cjson_util/cjson_util_file.h
+++ b/modules/cjson_util/module/inc/cjson_util/cjson_util_file.h
@@ -43,7 +43,7 @@ typedef struct cjson_util_file_s {
     char* filename;
 
     /** private */
-    time_t mtime;
+    uint64_t mtime;
     char* defaultj;
 } cjson_util_file_t;
 
@@ -67,7 +67,7 @@ void cjson_util_file_close(cjson_util_file_t* jfs);
  * @param force Force reload.
  * @returns 1 if reloaded, 0 if not reloaded.
  * @note The file will be reloaded if it has changed since the last time
- * it was loaderd, or if the reload is forced.
+ * it was loaded, or if the reload is forced.
  */
 int cjson_util_file_reload(cjson_util_file_t* jfs, int force);
 

--- a/modules/cjson_util/module/src/cjson_util_file.c
+++ b/modules/cjson_util/module/src/cjson_util_file.c
@@ -30,12 +30,13 @@
 #include "cjson_util_log.h"
 #include <cjson_util/cjson_util.h>
 
-static time_t
+static uint64_t
 mtime__(const char* fname)
 {
     struct stat st;
     if(stat(fname, &st) == 0) {
-        return st.st_mtime;
+        return (uint64_t) st.st_mtim.tv_sec * 1000*1000*1000
+            + st.st_mtim.tv_nsec;
     }
     else {
         return 0;
@@ -136,7 +137,7 @@ cjson_util_file_open(const char* fname, cjson_util_file_t* jfs,
 int
 cjson_util_file_reload(cjson_util_file_t* jfs, int force)
 {
-    time_t mtime = mtime__(jfs->filename);
+    uint64_t mtime = mtime__(jfs->filename);
     if( (mtime != jfs->mtime) || force ) {
         int rv = reload__(jfs);
         return (rv < 0) ? rv : 1;


### PR DESCRIPTION
Reviewer: @jnealtowns 

This pull request provides nanosecond resolution; please let me know it should be reduced to microsecond or millisecond resolution instead.  Thanks.
