### PR TITLE
cjson_util: cjson_util_file_open error handling

### DIFF
--- a/modules/cjson_util/module/src/cjson_util.c
+++ b/modules/cjson_util/module/src/cjson_util.c
@@ -31,6 +31,7 @@
 #include <limits.h>
 #include <math.h>
 #include <float.h>
+#include <errno.h>
 /*
  * Given the start of a string containing newlines and another pointer
  * inside that string, return the line and column number of that position.
@@ -77,6 +78,12 @@ cjson_util_parse_file(const char* filename, cJSON** result)
     data = aim_zmalloc(len + 1);
     if (fread(data, 1, len, f) == 0) {
         aim_free(data);
+        if (feof(f)) {
+            AIM_LOG_ERROR("%s: end of file", filename);
+        }
+        if (ferror(f)) {
+            AIM_LOG_ERROR("%s: %{errno}", filename, errno);
+        }
         fclose(f);
         AIM_LOG_ERROR("failed to read %s", filename);
         return AIM_ERROR_INTERNAL;

--- a/modules/cjson_util/module/src/cjson_util_file.c
+++ b/modules/cjson_util/module/src/cjson_util_file.c
@@ -101,7 +101,7 @@ static int reload__(cjson_util_file_t* jfs)
                     }
                 case AIM_ERROR_PARAM:
                     {
-                        AIM_LOG_ERROR("'%s' coudl not be parsed.", jfs->filename);
+                        AIM_LOG_ERROR("'%s' could not be parsed.", jfs->filename);
                         break;
                     }
                 default:
@@ -122,16 +122,12 @@ int
 cjson_util_file_open(const char* fname, cjson_util_file_t* jfs,
                      const char* defaultj)
 {
-    int rv;
     cjson_util_file_close(jfs);
     jfs->filename = aim_strdup(fname);
     if(defaultj) {
         jfs->defaultj = aim_strdup(defaultj);
     }
-    if( (rv = reload__(jfs)) < 0 ) {
-        cjson_util_file_close(jfs);
-    }
-    return rv;
+    return reload__(jfs);
 }
 
 int


### PR DESCRIPTION
Reviewer: @jnealtowns 
More logging when fread fails in cjson_util_parse_file
Do not clear jfs if reload__ fails in cjson_util_file_open

Clearing jfs means that if the initial file open fails, we lose the configured filename.