### PR TITLE
Fixing 25G CR as per SFF-8024_R4.7

### DIFF
--- a/modules/sff/module/inc/sff/8472.h
+++ b/modules/sff/module/inc/sff/8472.h
@@ -152,6 +152,9 @@
 #define SFF8472_CC36_100G_25G_LR          0x03
 #define SFF8472_CC36_100G_25G_AOC_1       0x01
 #define SFF8472_CC36_100G_25G_AOC_2       0x18
+#define SFF8472_CC36_100G_25G_50G_CR      0x0B
+#define SFF8472_CC36_25G_50G_CR_1         0x0C
+#define SFF8472_CC36_25G_50G_CR_2         0x0D
 
 #define SFF8471_CC60_FC_PI_4_LIMITING     0x08
 #define SFF8471_CC60_SFF8431_LIMITING     0x04
@@ -989,8 +992,10 @@ _sff8472_media_sfp28_cr(const uint8_t* idprom)
     /* module should be sfp */
     if (!SFF8472_MODULE_SFP(idprom)) return 0;
 
-    if ((idprom[3] & SFF8472_CC3_INF_1X_CU_PASSIVE) == 0) return 0;
-    if (idprom[12] == 0xFF) return 1;
+    if (idprom[12] != 0xFF) return 0;
+    if ((idprom[36] == SFF8472_CC36_100G_25G_50G_CR) ||
+         (idprom[36] == SFF8472_CC36_25G_50G_CR_1) ||
+         (idprom[36] == SFF8472_CC36_25G_50G_CR_2)) return 1;
 
     return 0;
 }


### PR DESCRIPTION
Currently few codes are added in the Extended Specification Compliance codes ( Table 4.4 in SFF-8024 Revision 4.7 ) , that you can refer to in byte 36 instead if applicable :
 
0Bh 100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS (Clause91) FEC
0Ch 25GBASE-CR CA-25G-S or 50GBASE-CR2 with BASE-R (Clause 74 Fire code) FEC
0Dh 25GBASE-CR CA-25G-N or 50GBASE-CR2 with no FEC